### PR TITLE
fix: parent-death watchdog and efficiency mode on macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,8 @@ jobs:
         run: cargo build --profile release
       - name: Run parity check
         run: ./scripts/parity_check.sh --no-build
+      - name: Run watchdog check
+        run: ./scripts/watchdog_check.sh
       - name: Build for aarch64
         run: cargo build --profile release --target aarch64-${{ env.TRIPLE_SUFFIX }}
       - name: Create universal binary

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,8 @@ jobs:
         run: cargo build --profile release
       - name: Run parity check
         run: ./scripts/parity_check.sh --no-build
+      - name: Run performance check
+        run: ./scripts/perf_check.sh
       - name: Run watchdog check
         run: ./scripts/watchdog_check.sh
         if: ${{ env.OS_NAME != 'windows' }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,6 +49,10 @@ jobs:
         run: ./scripts/parity_check.sh --no-build
       - name: Run watchdog check
         run: ./scripts/watchdog_check.sh
+        if: ${{ env.OS_NAME != 'windows' }}
+      - name: Run watchdog check (Windows)
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/watchdog_check.ps1
+        if: ${{ env.OS_NAME == 'windows' }}
       - name: Build for aarch64
         run: cargo build --profile release --target aarch64-${{ env.TRIPLE_SUFFIX }}
       - name: Create universal binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +203,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 name = "rust-watcher"
 version = "0.1.0"
 dependencies = [
+ "camino",
  "globset",
  "libc",
  "notify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,16 +34,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,12 +106,6 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "log"
@@ -216,23 +200,10 @@ dependencies = [
  "globset",
  "libc",
  "notify",
- "rustix",
  "serde",
  "serde_json",
  "walkdir",
  "windows",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.35"
-source = "git+https://github.com/ruihe774/rustix.git?branch=scheduler#26413e9facc6913b9752a54e35163009268aa310"
-dependencies = [
- "bitflags 2.11.1",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -432,20 +403,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -459,35 +421,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -501,21 +447,9 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -525,21 +459,9 @@ checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -549,21 +471,9 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -573,21 +483,9 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ name = "rust-watcher"
 version = "0.1.0"
 dependencies = [
  "globset",
+ "libc",
  "notify",
  "rustix",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ serde_json = "1"
 [target.'cfg(target_os = "linux")'.dependencies]
 rustix = { git = "https://github.com/ruihe774/rustix.git", branch = "scheduler", features = ["process", "event"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
+
 [target.'cfg(windows)'.dependencies]
 windows = { version = ">=0.51", features = ["Wdk_System_Threading", "Win32_System_Threading"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ notify = "8"
 walkdir = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+camino = "1.2.2"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,7 @@ walkdir = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
-[target.'cfg(target_os = "linux")'.dependencies]
-rustix = { git = "https://github.com/ruihe774/rustix.git", branch = "scheduler", features = ["process", "event"] }
-
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]

--- a/scripts/perf_check.sh
+++ b/scripts/perf_check.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# perf_check.sh — assert that registering a watcher on a realistic LSP-sized
+# tree completes promptly. Catches regressions like the FSEvents per-directory
+# stream-restart issue (sublimelsp/LSP-file-watcher-rust#3) where macOS
+# registration ballooned to >30 s.
+#
+# Strategy:
+#   1. Clone sublimelsp/LSP at a pinned commit (~289 files / 39 dirs).
+#   2. Pipe a single register message to rust-watcher and immediately close
+#      stdin. The binary processes register synchronously, then exits on EOF.
+#      Wall time is therefore an upper bound on register cost.
+#   3. Repeat a few times and fail if the best run exceeds the threshold.
+#
+# Works on: Linux, macOS, Windows (Git Bash).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RUST_BIN="$REPO_ROOT/target/release/rust-watcher"
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) RUST_BIN="$RUST_BIN.exe" ;;
+esac
+
+# Pinned LSP commit for reproducibility.
+LSP_REPO="https://github.com/sublimelsp/LSP.git"
+LSP_PIN="def3cf814b275c17f710306612138592efe7b764"
+WORKDIR="${TMPDIR:-/tmp}/lspfw-perf-$LSP_PIN"
+
+# Per-platform threshold (seconds). Generous enough to absorb CI noise but
+# tight enough to catch the FSEvents per-dir regression (which is >30 s).
+THRESHOLD=5
+
+if [[ ! -x "$RUST_BIN" ]]; then
+  echo "perf_check: $RUST_BIN not found — build the release binary first" >&2
+  exit 1
+fi
+
+if [[ ! -d "$WORKDIR/.git" ]]; then
+  echo "perf_check: cloning LSP at $LSP_PIN..."
+  rm -rf "$WORKDIR"
+  git clone --quiet "$LSP_REPO" "$WORKDIR"
+  git -C "$WORKDIR" checkout --quiet "$LSP_PIN"
+fi
+
+REG=$(printf '{"register":{"uid":1,"cwd":"%s","patterns":["**/*"],"events":["create","change","delete"],"ignores":[]}}' "$WORKDIR")
+
+# Pick the best of N runs to filter transient noise (cold-cache, scheduler).
+RUNS=3
+best_ms=999999
+for i in $(seq 1 "$RUNS"); do
+  t_start=$(python3 -c 'import time; print(int(time.monotonic()*1000))')
+  printf '%s\n' "$REG" | "$RUST_BIN" >/dev/null 2>&1
+  t_end=$(python3 -c 'import time; print(int(time.monotonic()*1000))')
+  elapsed=$(( t_end - t_start ))
+  echo "perf_check: run $i — ${elapsed} ms"
+  if (( elapsed < best_ms )); then
+    best_ms=$elapsed
+  fi
+done
+
+threshold_ms=$(( THRESHOLD * 1000 ))
+if (( best_ms > threshold_ms )); then
+  echo "perf_check: FAIL — best register time ${best_ms} ms exceeds threshold ${threshold_ms} ms" >&2
+  exit 1
+fi
+
+echo "perf_check: OK — best register time ${best_ms} ms (threshold ${threshold_ms} ms)"

--- a/scripts/watchdog_check.ps1
+++ b/scripts/watchdog_check.ps1
@@ -1,0 +1,83 @@
+#Requires -Version 5.1
+# watchdog_check.ps1 - Windows equivalent of watchdog_check.sh.
+#
+# Verify the parent-death watchdog terminates rust-watcher when its Win32
+# parent dies without closing stdin.
+#
+# Strategy:
+#   1. Spawn `cmd /c "<keeper> | rust-watcher.exe"`. cmd.exe creates an
+#      anonymous pipe, spawns the keeper (a long Start-Sleep) with stdout =
+#      pipe write-end, and spawns rust-watcher.exe with stdin = pipe read-end.
+#      cmd.exe is the Win32 parent of both children.
+#   2. TerminateProcess the wrapper cmd.exe. Windows does NOT propagate this
+#      to child processes, so the keeper survives and continues to hold the
+#      pipe write-end - rust-watcher's stdin therefore stays open. The only
+#      thing that can terminate rust-watcher is the parent-death watchdog
+#      thread (WaitForSingleObject on the parent process handle).
+#   3. Verify rust-watcher exits within a deadline. Clean up the orphaned
+#      keeper afterwards.
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$rustBin = Join-Path $repoRoot 'target\release\rust-watcher.exe'
+
+if (-not (Test-Path -LiteralPath $rustBin)) {
+    Write-Host "watchdog_check: $rustBin not found - build the release binary first"
+    exit 1
+}
+
+$keeperCmd = 'powershell.exe -NoProfile -Command "Start-Sleep -Seconds 60"'
+$pipeline  = "$keeperCmd | `"$rustBin`""
+
+$wrapper = Start-Process -FilePath 'cmd.exe' -ArgumentList '/c', $pipeline `
+    -PassThru -WindowStyle Hidden
+
+# Wait for rust-watcher.exe to appear as a child of the wrapper.
+$rustPid = 0
+for ($i = 0; $i -lt 50; $i++) {
+    Start-Sleep -Milliseconds 100
+    $proc = Get-CimInstance Win32_Process -Filter "Name = 'rust-watcher.exe' AND ParentProcessId = $($wrapper.Id)"
+    if ($proc) {
+        $rustPid = [int]$proc.ProcessId
+        break
+    }
+}
+if ($rustPid -eq 0) {
+    Write-Host "watchdog_check: FAIL - rust-watcher did not start"
+    Stop-Process -Id $wrapper.Id -Force -ErrorAction SilentlyContinue
+    exit 1
+}
+
+# Capture the keeper PID for cleanup before we kill the wrapper.
+$keeperProc = Get-CimInstance Win32_Process -Filter "Name = 'powershell.exe' AND ParentProcessId = $($wrapper.Id)"
+$keeperPid = if ($keeperProc) { [int]$keeperProc.ProcessId } else { 0 }
+
+# Orphan rust-watcher.
+Stop-Process -Id $wrapper.Id -Force
+
+# Watchdog must terminate rust-watcher within the deadline.
+$deadlineSec = 5
+$start = Get-Date
+$exited = $false
+while (((Get-Date) - $start).TotalSeconds -lt $deadlineSec) {
+    if (-not (Get-Process -Id $rustPid -ErrorAction SilentlyContinue)) {
+        $exited = $true
+        break
+    }
+    Start-Sleep -Milliseconds 100
+}
+
+if ($keeperPid -ne 0) {
+    Stop-Process -Id $keeperPid -Force -ErrorAction SilentlyContinue
+}
+
+if ($exited) {
+    $elapsed = [int]((Get-Date) - $start).TotalSeconds
+    Write-Host "watchdog_check: OK - rust-watcher (pid $rustPid) exited ${elapsed}s after parent death"
+    exit 0
+}
+
+Write-Host "watchdog_check: FAIL - rust-watcher (pid $rustPid) still alive ${deadlineSec}s after parent death"
+Stop-Process -Id $rustPid -Force -ErrorAction SilentlyContinue
+exit 1

--- a/scripts/watchdog_check.sh
+++ b/scripts/watchdog_check.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# watchdog_check.sh — verify the parent-death watchdog terminates rust-watcher
+# when its parent process dies without closing stdin.
+#
+# Strategy:
+#   1. Spawn a wrapper shell that launches rust-watcher with stdin held open by
+#      an unrelated subshell (`while sleep 60; do :; done`). When the wrapper
+#      dies, the subshell survives, so stdin will *not* EOF — the only thing
+#      that can terminate rust-watcher is the watchdog thread.
+#   2. SIGKILL the wrapper. rust-watcher is now orphaned.
+#   3. Verify the watchdog kills rust-watcher within a deadline.
+#
+# Works on: Linux, macOS, Windows (Git Bash).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RUST_BIN="$REPO_ROOT/target/release/rust-watcher"
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) RUST_BIN="$RUST_BIN.exe" ;;
+esac
+
+if [[ ! -x "$RUST_BIN" ]]; then
+  echo "watchdog_check: $RUST_BIN not found — build the release binary first" >&2
+  exit 1
+fi
+
+PIDFILE=$(mktemp)
+WRAPPER_SCRIPT=$(mktemp)
+trap 'rm -f "$PIDFILE" "$WRAPPER_SCRIPT"' EXIT
+
+cat > "$WRAPPER_SCRIPT" <<EOF
+#!/usr/bin/env bash
+"$RUST_BIN" < <(while sleep 60; do :; done) &
+echo \$! > "$PIDFILE"
+wait
+EOF
+chmod +x "$WRAPPER_SCRIPT"
+
+"$WRAPPER_SCRIPT" &
+WRAPPER_PID=$!
+
+# Wait for rust-watcher to start.
+for _ in $(seq 1 50); do
+  [[ -s "$PIDFILE" ]] && break
+  sleep 0.1
+done
+RUST_PID=$(cat "$PIDFILE" 2>/dev/null || true)
+if [[ -z "$RUST_PID" ]] || ! kill -0 "$RUST_PID" 2>/dev/null; then
+  echo "watchdog_check: FAIL — rust-watcher did not start" >&2
+  kill -9 "$WRAPPER_PID" 2>/dev/null || true
+  exit 1
+fi
+
+# Orphan rust-watcher.
+kill -9 "$WRAPPER_PID"
+wait "$WRAPPER_PID" 2>/dev/null || true
+
+# Watchdog must terminate rust-watcher within the deadline.
+DEADLINE_S=5
+START=$(date +%s)
+while :; do
+  if ! kill -0 "$RUST_PID" 2>/dev/null; then
+    elapsed=$(( $(date +%s) - START ))
+    echo "watchdog_check: OK — rust-watcher (pid $RUST_PID) exited ${elapsed}s after parent death"
+    exit 0
+  fi
+  if (( $(date +%s) - START >= DEADLINE_S )); then
+    echo "watchdog_check: FAIL — rust-watcher (pid $RUST_PID) still alive ${DEADLINE_S}s after parent death" >&2
+    kill -9 "$RUST_PID" 2>/dev/null || true
+    exit 1
+  fi
+  sleep 0.1
+done

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ fn parent_process_watchdog() -> ! {
             parent_died();
         }
         if n < 0 {
-            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+            let errno = io::Error::last_os_error().raw_os_error().unwrap_or(0);
             if errno != libc::EINTR {
                 parent_died();
             }
@@ -100,7 +100,7 @@ fn parent_process_watchdog() -> ! {
             parent_died();
         }
         if n < 0 {
-            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+            let errno = io::Error::last_os_error().raw_os_error().unwrap_or(0);
             if errno != libc::EINTR {
                 parent_died();
             }
@@ -140,7 +140,7 @@ fn parent_process_watchdog() -> ! {
 
 #[cfg(target_os = "linux")]
 fn enter_efficiency_mode() {
-    let param: libc::sched_param = unsafe { std::mem::zeroed() };
+    let param: libc::sched_param = unsafe { mem::zeroed() };
     let _ = unsafe { libc::sched_setscheduler(0, libc::SCHED_BATCH, &raw const param) };
 }
 
@@ -661,29 +661,49 @@ impl WatcherState {
     }
 }
 
-// Owns the single RecommendedWatcher and refcounts OS-level directory watches.
+// FSEvents on macOS is inherently recursive and incurs a full stream
+// stop/restart per `watch()` call (see notify::fsevent::watch_inner). Acquiring
+// one watch per directory under cwd would mean N stream restarts for an
+// initial scan, taking ~1 s each on real projects. Instead we install a single
+// recursive watch on each registration's cwd and rely on PatternMatcher /
+// WatcherState to filter sub-tree events in user space (mirroring chokidar 3).
+//
+// On Linux/Windows the inotify/ReadDirectoryChangesW backends do not support
+// recursive natively, so notify simulates it by watching each directory
+// individually. With overlapping registrations (common in LSP), per-dir
+// refcounting via Hub avoids redundant kernel-level watches on the same inode.
+#[cfg(target_os = "macos")]
+const WATCH_MODE: notify::RecursiveMode = notify::RecursiveMode::Recursive;
+#[cfg(not(target_os = "macos"))]
+const WATCH_MODE: notify::RecursiveMode = notify::RecursiveMode::NonRecursive;
+
+// Owns the single RecommendedWatcher and refcounts OS-level watches.
+//
+// On Linux/Windows the keys are every directory inside each registration's
+// tracked subtree. On macOS the keys are the registration cwds (one recursive
+// watch per cwd, deduplicated across overlapping registrations).
 struct Hub {
     watcher: notify::RecommendedWatcher,
-    dir_refs: HashMap<PathBuf, usize>,
+    refs: HashMap<PathBuf, usize>,
 }
 
 impl Hub {
-    fn acquire(&mut self, dir: &Path) {
-        let n = self.dir_refs.entry(dir.to_path_buf()).or_insert(0);
+    fn acquire(&mut self, path: &Path) {
+        let n = self.refs.entry(path.to_path_buf()).or_insert(0);
         *n += 1;
         if *n == 1 {
-            if let Err(e) = self.watcher.watch(dir, notify::RecursiveMode::NonRecursive) {
-                eprintln!("watch({}) failed: {e:?}", dir.display());
+            if let Err(e) = self.watcher.watch(path, WATCH_MODE) {
+                eprintln!("watch({}) failed: {e:?}", path.display());
             }
         }
     }
 
-    fn release(&mut self, dir: &Path) {
-        if let Some(n) = self.dir_refs.get_mut(dir) {
+    fn release(&mut self, path: &Path) {
+        if let Some(n) = self.refs.get_mut(path) {
             *n -= 1;
             if *n == 0 {
-                self.dir_refs.remove(dir);
-                let _ = self.watcher.unwatch(dir);
+                self.refs.remove(path);
+                let _ = self.watcher.unwatch(path);
             }
         }
     }
@@ -701,7 +721,13 @@ fn register_watcher(reg: Register, hub: HubHandle, states: States) {
     let mut state = WatcherState::new(uid, cwd, reg.events, matcher);
     state.initial_scan();
 
-    // Acquire one non-recursive OS watch per directory discovered in the scan.
+    // macOS: a single recursive FSEvents watch on cwd covers the whole subtree.
+    // Other OSes: one non-recursive watch per directory discovered in the scan.
+    #[cfg(target_os = "macos")]
+    {
+        hub.lock().unwrap().acquire(&state.cwd);
+    }
+    #[cfg(not(target_os = "macos"))]
     {
         let dirs: Vec<PathBuf> = state.tracked_dirs.keys().cloned().collect();
         let mut h = hub.lock().unwrap();
@@ -744,6 +770,9 @@ fn dispatch_worker(
             }
         }
 
+        // The recursive macOS watch already covers any new sub-directory, so
+        // the deltas WatcherState produces are simply discarded there.
+        #[cfg(not(target_os = "macos"))]
         if !acquired.is_empty() || !released.is_empty() {
             let mut h = hub.lock().unwrap();
             for dir in acquired {
@@ -873,7 +902,7 @@ fn main() {
 
     let hub: HubHandle = Box::leak(Box::new(Mutex::new(Hub {
         watcher,
-        dir_refs: HashMap::new(),
+        refs: HashMap::new(),
     })));
 
     drop(thread::spawn(move || {
@@ -900,12 +929,19 @@ fn main() {
                 match state {
                     None => eprintln!("watcher with ID {uid} not found"),
                     Some(arc) => {
-                        // Collect dirs while we still have the Arc.
-                        let dirs: Vec<PathBuf> =
-                            arc.lock().unwrap().tracked_dirs.keys().cloned().collect();
-                        let mut h = hub.lock().unwrap();
-                        for dir in dirs {
-                            h.release(&dir);
+                        #[cfg(target_os = "macos")]
+                        {
+                            let cwd = arc.lock().unwrap().cwd.clone();
+                            hub.lock().unwrap().release(&cwd);
+                        }
+                        #[cfg(not(target_os = "macos"))]
+                        {
+                            let dirs: Vec<PathBuf> =
+                                arc.lock().unwrap().tracked_dirs.keys().cloned().collect();
+                            let mut h = hub.lock().unwrap();
+                            for dir in dirs {
+                                h.release(&dir);
+                            }
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@ use notify::Watcher as _;
 use serde::Deserialize;
 use walkdir::WalkDir;
 
-#[cfg(any(target_os = "linux", target_os = "macos", windows))]
 fn parent_died() -> ! {
     eprintln!("parent process died");
     exit(1);
@@ -163,8 +162,10 @@ fn enter_efficiency_mode() {
     };
 }
 
-#[cfg(not(any(target_os = "linux", windows)))]
-fn enter_efficiency_mode() {}
+#[cfg(target_os = "macos")]
+fn enter_efficiency_mode() {
+    let _ = unsafe { libc::setpriority(libc::PRIO_DARWIN_PROCESS, 0, libc::PRIO_DARWIN_BG) };
+}
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -844,16 +845,11 @@ fn handle_reports(queue: Queue, states: States) -> ! {
 }
 
 fn main() {
-    #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
-    compile_error!("unsupported platform");
-
-    #[cfg(any(target_os = "linux", windows))]
+    #[cfg(any(target_os = "linux", target_os = "macos", windows))]
     {
         enter_efficiency_mode();
         drop(thread::spawn(parent_process_watchdog));
     }
-    #[cfg(target_os = "macos")]
-    drop(thread::spawn(parent_process_watchdog));
 
     let queue: Queue = Box::leak(Box::new(Mutex::new(Vec::new())));
     let states: States = Box::leak(Box::new(Mutex::new(HashMap::new())));

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ fn parent_process_watchdog() -> ! {
 #[cfg(target_os = "macos")]
 fn parent_process_watchdog() -> ! {
     use libc::{kevent, kqueue, EVFILT_PROC, EV_ADD, EV_ONESHOT, NOTE_EXIT};
+    use std::ptr::{null, null_mut};
 
     let ppid = unsafe { libc::getppid() };
     if ppid <= 1 {
@@ -75,27 +76,18 @@ fn parent_process_watchdog() -> ! {
         flags: EV_ADD | EV_ONESHOT,
         fflags: NOTE_EXIT,
         data: 0,
-        udata: std::ptr::null_mut(),
+        udata: null_mut(),
     };
 
     // Registration returns ESRCH if the parent already died.
-    let ret = unsafe {
-        kevent(
-            kq,
-            &raw const change,
-            1,
-            std::ptr::null_mut(),
-            0,
-            std::ptr::null(),
-        )
-    };
+    let ret = unsafe { kevent(kq, &raw const change, 1, null_mut(), 0, null()) };
     if ret < 0 {
         parent_died();
     }
 
-    let mut event = unsafe { std::mem::zeroed::<kevent>() };
+    let mut event = unsafe { mem::zeroed::<kevent>() };
     loop {
-        let n = unsafe { kevent(kq, std::ptr::null(), 0, &raw mut event, 1, std::ptr::null()) };
+        let n = unsafe { kevent(kq, null(), 0, &raw mut event, 1, null()) };
         if n > 0 {
             parent_died();
         }
@@ -115,13 +107,14 @@ fn parent_process_watchdog() -> ! {
         GetCurrentProcess, OpenProcess, WaitForSingleObject, INFINITE, PROCESS_ACCESS_RIGHTS,
     };
 
-    let mut info = [0usize; 6];
+    let mut info = [0_usize; 6];
     let mut r_len = 0;
+    let current_process = unsafe { GetCurrentProcess() };
     assert!(unsafe {
         NtQueryInformationProcess(
-            GetCurrentProcess(),
+            current_process,
             PROCESSINFOCLASS(0),
-            info.as_mut_ptr() as _,
+            info.as_mut_ptr().cast(),
             (size_of::<usize>() * 6) as _,
             &raw mut r_len,
         )
@@ -130,7 +123,7 @@ fn parent_process_watchdog() -> ! {
     assert_eq!(r_len as usize, size_of::<usize>() * 6);
 
     let ppid = info[5] as u32;
-    let Ok(pph) = (unsafe { OpenProcess(PROCESS_ACCESS_RIGHTS(0x00100000), false, ppid) }) else {
+    let Ok(pph) = (unsafe { OpenProcess(PROCESS_ACCESS_RIGHTS(0x0010_0000), false, ppid) }) else {
         parent_died();
     };
 
@@ -159,11 +152,12 @@ fn enter_efficiency_mode() {
         StateMask: PROCESS_POWER_THROTTLING_EXECUTION_SPEED
             | PROCESS_POWER_THROTTLING_IGNORE_TIMER_RESOLUTION,
     };
+    let current_process = unsafe { GetCurrentProcess() };
     let _ = unsafe {
         SetProcessInformation(
-            GetCurrentProcess(),
+            current_process,
             ProcessPowerThrottling,
-            &raw const info as _,
+            (&raw const info).cast(),
             size_of::<PROCESS_POWER_THROTTLING_STATE>() as _,
         )
     };
@@ -742,6 +736,7 @@ fn register_watcher(reg: Register, hub: HubHandle, states: States) {
 
 fn dispatch_worker(
     rx: mpsc::Receiver<notify::Event>,
+    #[allow(unused_variables)]
     hub: HubHandle,
     queue: Queue,
     states: States,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,16 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
-use std::ffi::OsString;
 use std::fmt;
 use std::fs;
 use std::io::{self, BufWriter, Write as _};
 use std::mem;
-use std::path::{self, Path, PathBuf};
+use std::path;
 use std::process::exit;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use camino::{Utf8Path, Utf8PathBuf};
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use notify::Watcher as _;
 use serde::Deserialize;
@@ -190,7 +190,7 @@ impl fmt::Display for EventType {
 struct Report {
     uid: usize,
     event: EventType,
-    path: PathBuf,
+    path: Utf8PathBuf,
     timestamp: Instant,
 }
 
@@ -221,11 +221,11 @@ enum PathKind {
     File,
 }
 
-fn classify(path: &Path) -> Option<PathKind> {
+fn classify(path: &Utf8Path) -> Option<PathKind> {
     match fs::symlink_metadata(path) {
         Err(e) if e.kind() == io::ErrorKind::NotFound => Some(PathKind::Missing),
         Err(e) => {
-            eprintln!("watcher: stat error for {}: {e}", path.display());
+            eprintln!("watcher: stat error for {path}: {e}");
             None
         }
         Ok(m) if m.is_dir() => Some(PathKind::Dir),
@@ -233,16 +233,17 @@ fn classify(path: &Path) -> Option<PathKind> {
     }
 }
 
-fn normalize_pattern(cwd: &Path, pat: &str) -> PathBuf {
+fn normalize_pattern(cwd: &Utf8Path, pat: &str) -> Utf8PathBuf {
     #[cfg(windows)]
     let pat = pat.replace('/', "\\");
 
-    let p = Path::new(&pat);
+    let p = Utf8Path::new(&pat);
     if p.is_absolute() {
-        PathBuf::from(p)
+        p.to_owned()
     } else {
-        // path::absolute normalises `.` and `..` without touching glob metacharacters
-        path::absolute(cwd.join(p)).unwrap_or_else(|_| cwd.join(p))
+        // absolute_utf8 normalises `.` and `..` without touching glob metacharacters
+        let joined = cwd.join(p);
+        camino::absolute_utf8(&joined).unwrap_or(joined)
     }
 }
 
@@ -261,23 +262,23 @@ fn build_globset(patterns: impl IntoIterator<Item = impl AsRef<str>>) -> GlobSet
 }
 
 struct PatternMatcher {
-    literal_files: HashSet<PathBuf>,
-    literal_dirs: Vec<PathBuf>,
+    literal_files: HashSet<Utf8PathBuf>,
+    literal_dirs: Vec<Utf8PathBuf>,
     glob_set: GlobSet,
     ignore_set: GlobSet,
 }
 
 impl PatternMatcher {
-    fn new(cwd: &Path, patterns: &[String], ignores: &[String]) -> Self {
+    fn new(cwd: &Utf8Path, patterns: &[String], ignores: &[String]) -> Self {
         let mut literal_files = HashSet::new();
-        let mut literal_dirs: Vec<PathBuf> = Vec::new();
+        let mut literal_dirs: Vec<Utf8PathBuf> = Vec::new();
         let mut glob_patterns: Vec<String> = Vec::new();
         let mut ignore_patterns: Vec<String> = Vec::new();
 
         for pat in patterns {
             let abs = normalize_pattern(cwd, pat);
             if is_glob_str(pat) {
-                glob_patterns.push(abs.to_string_lossy().into_owned());
+                glob_patterns.push(abs.into_string());
             } else if abs.is_dir() {
                 literal_dirs.push(abs);
             } else {
@@ -287,7 +288,7 @@ impl PatternMatcher {
 
         for ign in ignores {
             let abs = normalize_pattern(cwd, ign);
-            let mut abs_str = abs.to_string_lossy().into_owned();
+            let mut abs_str = abs.into_string();
             if !is_glob_str(ign) {
                 // literal ignore: also add path/** to exclude children
                 let mut with_children = abs_str.clone();
@@ -306,40 +307,39 @@ impl PatternMatcher {
         }
     }
 
-    fn matches(&self, path: &Path) -> bool {
+    fn matches(&self, path: &Utf8Path) -> bool {
         self.literal_files.contains(path)
             || self.literal_dirs.iter().any(|d| path.starts_with(d))
             || self.glob_set.is_match(path)
     }
 
-    fn is_ignored(&self, path: &Path) -> bool {
+    fn is_ignored(&self, path: &Utf8Path) -> bool {
         if self.ignore_set.is_match(path) {
             return true;
         }
         // Mirror chokidar's DOT_RE: /\..*\.(sw[px])$|~$|\.subl.*\.tmp/
         // tested against the full path string.
-        if let Some(s) = path.to_str() {
-            if s.ends_with('~') {
-                return true;
-            }
-            for suffix in [".swp", ".swx", ".swpx"] {
-                if let Some(stripped) = s.strip_suffix(suffix) {
-                    // \..*\.swp$ requires a dot before the trailing suffix.
-                    if stripped.contains('.') {
-                        return true;
-                    }
-                }
-            }
-            if let Some(idx) = s.find(".subl") {
-                if s[idx + ".subl".len()..].contains(".tmp") {
+        let s = path.as_str();
+        if s.ends_with('~') {
+            return true;
+        }
+        for suffix in [".swp", ".swx", ".swpx"] {
+            if let Some(stripped) = s.strip_suffix(suffix) {
+                // \..*\.swp$ requires a dot before the trailing suffix.
+                if stripped.contains('.') {
                     return true;
                 }
+            }
+        }
+        if let Some(idx) = s.find(".subl") {
+            if s[idx + ".subl".len()..].contains(".tmp") {
+                return true;
             }
         }
         false
     }
 
-    fn is_emittable(&self, path: &Path) -> bool {
+    fn is_emittable(&self, path: &Utf8Path) -> bool {
         self.matches(path) && !self.is_ignored(path)
     }
 }
@@ -350,23 +350,23 @@ const ATOMIC_WINDOW_MS: u64 = 100;
 
 struct WatcherState {
     uid: usize,
-    cwd: PathBuf,
+    cwd: Utf8PathBuf,
     events: Vec<EventType>,
     matcher: PatternMatcher,
     // Every emittable file we currently know about.
-    tracked_files: HashSet<PathBuf>,
+    tracked_files: HashSet<Utf8PathBuf>,
     // Tracked directory → set of child basenames (dirs and emittable files).
-    tracked_dirs: HashMap<PathBuf, HashSet<OsString>>,
+    tracked_dirs: HashMap<Utf8PathBuf, HashSet<String>>,
     // Per-path last-emit timestamps for throttling.
-    last_change: HashMap<PathBuf, Instant>,
-    last_remove: HashMap<PathBuf, Instant>,
+    last_change: HashMap<Utf8PathBuf, Instant>,
+    last_remove: HashMap<Utf8PathBuf, Instant>,
     // Deferred delete events (atomic-write detection).
     // Value = original event time (deadline = value + ATOMIC_WINDOW_MS).
-    pending_unlinks: HashMap<PathBuf, Instant>,
+    pending_unlinks: HashMap<Utf8PathBuf, Instant>,
 }
 
 impl WatcherState {
-    fn new(uid: usize, cwd: PathBuf, events: Vec<EventType>, matcher: PatternMatcher) -> Self {
+    fn new(uid: usize, cwd: Utf8PathBuf, events: Vec<EventType>, matcher: PatternMatcher) -> Self {
         Self {
             uid,
             cwd,
@@ -391,13 +391,14 @@ impl WatcherState {
             tracked_files,
             ..
         } = self;
-        let walker = WalkDir::new(&*cwd).follow_links(false);
-        for entry in walker
-            .into_iter()
-            .filter_entry(|e| e.path() == *cwd || !matcher.is_ignored(e.path()))
-        {
+        let walker = WalkDir::new(cwd.as_std_path()).follow_links(false);
+        for entry in walker.into_iter().filter_entry(|e| {
+            Utf8Path::from_path(e.path()).is_none_or(|p| p == *cwd || !matcher.is_ignored(p))
+        }) {
             let Ok(entry) = entry else { continue };
-            let path = entry.path().to_path_buf();
+            let Some(path) = Utf8Path::from_path(entry.path()).map(Utf8Path::to_path_buf) else {
+                continue;
+            };
             let file_type = entry.file_type();
 
             if file_type.is_dir() {
@@ -406,7 +407,7 @@ impl WatcherState {
                         tracked_dirs
                             .entry(parent.to_path_buf())
                             .or_default()
-                            .insert(name.to_os_string());
+                            .insert(name.to_owned());
                     }
                 }
                 tracked_dirs.entry(path).or_default();
@@ -416,7 +417,7 @@ impl WatcherState {
                     tracked_dirs
                         .entry(parent.to_path_buf())
                         .or_default()
-                        .insert(name.to_os_string());
+                        .insert(name.to_owned());
                 }
                 tracked_files.insert(path);
             }
@@ -425,11 +426,11 @@ impl WatcherState {
 
     fn dispatch(
         &mut self,
-        path: &Path,
+        path: &Utf8Path,
         kind: PathKind,
         queue: &mut Vec<Report>,
-        acquired: &mut Vec<PathBuf>,
-        released: &mut Vec<PathBuf>,
+        acquired: &mut Vec<Utf8PathBuf>,
+        released: &mut Vec<Utf8PathBuf>,
     ) {
         if !path.starts_with(&self.cwd) {
             return;
@@ -441,13 +442,13 @@ impl WatcherState {
         }
     }
 
-    fn handle_deletion(&mut self, path: PathBuf, released: &mut Vec<PathBuf>) {
+    fn handle_deletion(&mut self, path: Utf8PathBuf, released: &mut Vec<Utf8PathBuf>) {
         let parent = match path.parent() {
             Some(p) => p.to_path_buf(),
             None => return,
         };
         let name = match path.file_name() {
-            Some(n) => n.to_os_string(),
+            Some(n) => n.to_owned(),
             None => return,
         };
 
@@ -501,10 +502,10 @@ impl WatcherState {
 
     fn handle_directory(
         &mut self,
-        path: PathBuf,
+        path: Utf8PathBuf,
         queue: &mut Vec<Report>,
-        acquired: &mut Vec<PathBuf>,
-        released: &mut Vec<PathBuf>,
+        acquired: &mut Vec<Utf8PathBuf>,
+        released: &mut Vec<Utf8PathBuf>,
     ) {
         // Take the previous child set out of self so we can mutate `self`
         // freely below without re-borrowing it for the diff.
@@ -517,12 +518,12 @@ impl WatcherState {
                 self.tracked_dirs
                     .entry(parent.to_path_buf())
                     .or_default()
-                    .insert(name.to_os_string());
+                    .insert(name.to_owned());
             }
         }
 
         // Snapshot what's currently on disk (filtered).
-        let current: HashSet<OsString> = match fs::read_dir(&path) {
+        let current: HashSet<String> = match fs::read_dir(&path) {
             Err(_) => {
                 // Restore the previous tracking so we don't lose state on a transient stat failure.
                 self.tracked_dirs.insert(path, prev);
@@ -531,27 +532,28 @@ impl WatcherState {
             Ok(rd) => rd
                 .filter_map(Result::ok)
                 .filter_map(|entry| {
-                    let cp = entry.path();
+                    let cp = Utf8PathBuf::from_path_buf(entry.path()).ok()?;
+                    let name = entry.file_name().into_string().ok()?;
                     let ft = entry.file_type().ok()?;
                     if ft.is_dir() {
                         if self.matcher.is_ignored(&cp) {
                             None
                         } else {
-                            Some(entry.file_name())
+                            Some(name)
                         }
                     } else {
-                        self.matcher.is_emittable(&cp).then(|| entry.file_name())
+                        self.matcher.is_emittable(&cp).then_some(name)
                     }
                 })
                 .collect(),
         };
 
-        // Partition by moving OsStrings instead of cloning:
+        // Partition by moving Strings instead of cloning:
         //   - in current and prev   → intersection (still tracked)
         //   - in current, not prev  → new_entries  (dispatch as new)
         //   - in prev, not current  → gone        (left in `prev`, then deleted)
-        let mut new_entries: Vec<OsString> = Vec::new();
-        let mut intersection: HashSet<OsString> = HashSet::with_capacity(prev.len());
+        let mut new_entries: Vec<String> = Vec::new();
+        let mut intersection: HashSet<String> = HashSet::with_capacity(prev.len());
         for name in current {
             if prev.remove(&name) {
                 intersection.insert(name);
@@ -582,7 +584,7 @@ impl WatcherState {
             .extend(intersection);
     }
 
-    fn handle_file(&mut self, path: PathBuf, queue: &mut Vec<Report>) {
+    fn handle_file(&mut self, path: Utf8PathBuf, queue: &mut Vec<Report>) {
         if !self.matcher.is_emittable(&path) {
             return;
         }
@@ -592,7 +594,7 @@ impl WatcherState {
             None => return,
         };
         let name = match path.file_name() {
-            Some(n) => n.to_os_string(),
+            Some(n) => n.to_owned(),
             None => return,
         };
 
@@ -643,7 +645,7 @@ impl WatcherState {
         }
     }
 
-    fn allow_change(&mut self, path: &Path, now: Instant) -> bool {
+    fn allow_change(&mut self, path: &Utf8Path, now: Instant) -> bool {
         if let Some(&last) = self.last_change.get(path) {
             if now.duration_since(last) < Duration::from_millis(CHANGE_THROTTLE_MS) {
                 return false;
@@ -710,26 +712,26 @@ const WATCH_MODE: notify::RecursiveMode = notify::RecursiveMode::NonRecursive;
 // watch per cwd, deduplicated across overlapping registrations).
 struct Hub {
     watcher: notify::RecommendedWatcher,
-    refs: HashMap<PathBuf, usize>,
+    refs: HashMap<Utf8PathBuf, usize>,
 }
 
 impl Hub {
-    fn acquire(&mut self, path: &Path) {
+    fn acquire(&mut self, path: &Utf8Path) {
         let n = self.refs.entry(path.to_path_buf()).or_insert(0);
         *n += 1;
         if *n == 1 {
-            if let Err(e) = self.watcher.watch(path, WATCH_MODE) {
-                eprintln!("watch({}) failed: {e:?}", path.display());
+            if let Err(e) = self.watcher.watch(path.as_std_path(), WATCH_MODE) {
+                eprintln!("watch({path}) failed: {e:?}");
             }
         }
     }
 
-    fn release(&mut self, path: &Path) {
+    fn release(&mut self, path: &Utf8Path) {
         if let Some(n) = self.refs.get_mut(path) {
             *n -= 1;
             if *n == 0 {
                 self.refs.remove(path);
-                let _ = self.watcher.unwatch(path);
+                let _ = self.watcher.unwatch(path.as_std_path());
             }
         }
     }
@@ -741,7 +743,7 @@ type HubHandle = &'static Mutex<Hub>;
 
 fn register_watcher(reg: Register, hub: HubHandle, states: States) {
     let uid = reg.uid;
-    let cwd = path::absolute(&reg.cwd).unwrap_or_else(|_| PathBuf::from(&reg.cwd));
+    let cwd = camino::absolute_utf8(&reg.cwd).unwrap_or_else(|_| Utf8PathBuf::from(&reg.cwd));
     let matcher = PatternMatcher::new(&cwd, &reg.patterns, &reg.ignores);
 
     let mut state = WatcherState::new(uid, cwd, reg.events, matcher);
@@ -755,7 +757,7 @@ fn register_watcher(reg: Register, hub: HubHandle, states: States) {
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let dirs: Vec<PathBuf> = state.tracked_dirs.keys().cloned().collect();
+        let dirs: Vec<Utf8PathBuf> = state.tracked_dirs.keys().cloned().collect();
         let mut h = hub.lock().unwrap();
         for dir in dirs {
             h.acquire(&dir);
@@ -774,9 +776,10 @@ fn dispatch_worker(
 ) {
     while let Ok(event) = rx.recv() {
         // Stat each path once; reuse across all watchers.
-        let path_kinds: Vec<(PathBuf, PathKind)> = event
+        let path_kinds: Vec<(Utf8PathBuf, PathKind)> = event
             .paths
             .into_iter()
+            .filter_map(|p| Utf8PathBuf::from_path_buf(p).ok())
             .filter_map(|p| classify(&p).map(|k| (p, k)))
             .collect();
 
@@ -786,8 +789,8 @@ fn dispatch_worker(
         };
 
         let mut reports: Vec<Report> = Vec::new();
-        let mut acquired: Vec<PathBuf> = Vec::new();
-        let mut released: Vec<PathBuf> = Vec::new();
+        let mut acquired: Vec<Utf8PathBuf> = Vec::new();
+        let mut released: Vec<Utf8PathBuf> = Vec::new();
 
         for state_arc in state_arcs {
             let mut s = state_arc.lock().unwrap();
@@ -865,7 +868,7 @@ fn handle_reports(queue: Queue, states: States) -> ! {
         };
 
         // Collapse overlapping events for the same (uid, path), preserving order.
-        let mut path_states: HashMap<(usize, PathBuf), (usize, EventType)> = HashMap::new();
+        let mut path_states: HashMap<(usize, Utf8PathBuf), (usize, EventType)> = HashMap::new();
         for (i, report) in q.into_iter().enumerate() {
             let Report {
                 uid, event, path, ..
@@ -900,7 +903,7 @@ fn handle_reports(queue: Queue, states: States) -> ! {
 
         let mut stdout = BufWriter::new(io::stdout().lock());
         for (_, uid, event, path) in ordered {
-            let _ = writeln!(stdout, "{}:{}:{}", uid, event, path.display());
+            let _ = writeln!(stdout, "{uid}:{event}:{path}");
         }
         let _ = writeln!(stdout, "<flush>");
     }
@@ -962,7 +965,7 @@ fn main() {
                         }
                         #[cfg(not(target_os = "macos"))]
                         {
-                            let dirs: Vec<PathBuf> =
+                            let dirs: Vec<Utf8PathBuf> =
                                 arc.lock().unwrap().tracked_dirs.keys().cloned().collect();
                             let mut h = hub.lock().unwrap();
                             for dir in dirs {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,25 +23,33 @@ fn parent_died() -> ! {
 
 #[cfg(target_os = "linux")]
 fn parent_process_watchdog() -> ! {
-    use rustix::event::{poll, PollFd, PollFlags};
-    use rustix::io::Errno;
-    use rustix::process::{getppid, pidfd_open, PidfdFlags};
-
-    let Some(ppid) = getppid() else {
+    let ppid = unsafe { libc::getppid() };
+    if ppid <= 1 {
         parent_died();
-    };
+    }
 
-    let Ok(ppid_fd) = pidfd_open(ppid, PidfdFlags::empty()) else {
+    let pidfd = unsafe { libc::syscall(libc::SYS_pidfd_open, ppid, 0) };
+    if pidfd < 0 {
         parent_died();
-    };
+    }
 
-    let mut fds = [PollFd::new(&ppid_fd, PollFlags::IN)];
+    #[allow(clippy::cast_possible_truncation)]
+    let mut fds = [libc::pollfd {
+        fd: pidfd as i32,
+        events: libc::POLLIN,
+        revents: 0,
+    }];
 
     loop {
-        match poll(&mut fds, -1) {
-            Ok(_) => parent_died(),
-            Err(Errno::INTR) => {}
-            Err(e) => panic!("poll failed: {e:?}"),
+        let n = unsafe { libc::poll(fds.as_mut_ptr(), 1, -1) };
+        if n > 0 {
+            parent_died();
+        }
+        if n < 0 {
+            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+            if errno != libc::EINTR {
+                parent_died();
+            }
         }
     }
 }
@@ -132,9 +140,8 @@ fn parent_process_watchdog() -> ! {
 
 #[cfg(target_os = "linux")]
 fn enter_efficiency_mode() {
-    use rustix::process::{sched_setscheduler, SchedParam, SchedPolicy};
-
-    let _ = sched_setscheduler(None, SchedPolicy::Batch, &SchedParam::default());
+    let param: libc::sched_param = unsafe { std::mem::zeroed() };
+    let _ = unsafe { libc::sched_setscheduler(0, libc::SCHED_BATCH, &raw const param) };
 }
 
 #[cfg(windows)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,7 +211,7 @@ enum Request {
 }
 
 fn is_glob_str(s: &str) -> bool {
-    s.contains('*') || s.contains('?') || s.contains('{') || s.contains('[') || s.starts_with('!')
+    s.bytes().next() == Some(b'!') || s.bytes().any(|ch| matches!(ch, b'*' | b'?' | b'{' | b'['))
 }
 
 #[derive(Copy, Clone)]
@@ -287,14 +287,15 @@ impl PatternMatcher {
 
         for ign in ignores {
             let abs = normalize_pattern(cwd, ign);
-            let abs_str = abs.to_string_lossy().into_owned();
-            if is_glob_str(ign) {
-                ignore_patterns.push(abs_str);
-            } else {
+            let mut abs_str = abs.to_string_lossy().into_owned();
+            if !is_glob_str(ign) {
                 // literal ignore: also add path/** to exclude children
-                ignore_patterns.push(abs_str.clone());
-                ignore_patterns.push(format!("{}{sep}**", abs_str, sep = path::MAIN_SEPARATOR));
+                let mut with_children = abs_str.clone();
+                with_children.extend([path::MAIN_SEPARATOR, '*', '*']);
+                mem::swap(&mut abs_str, &mut with_children);
+                ignore_patterns.push(with_children);
             }
+            ignore_patterns.push(abs_str);
         }
 
         Self {
@@ -380,36 +381,44 @@ impl WatcherState {
     }
 
     fn initial_scan(&mut self) {
-        let cwd = self.cwd.clone();
-        let walker = WalkDir::new(&cwd).follow_links(false);
+        // Disjoint field borrows: the walker's filter_entry closure captures
+        // `cwd` and `matcher` immutably while the loop body mutates the two
+        // tracking maps — keeps `self.cwd` accessible without cloning.
+        let Self {
+            cwd,
+            matcher,
+            tracked_dirs,
+            tracked_files,
+            ..
+        } = self;
+        let walker = WalkDir::new(&*cwd).follow_links(false);
         for entry in walker
             .into_iter()
-            .filter_entry(|e| e.path() == cwd || !self.matcher.is_ignored(e.path()))
+            .filter_entry(|e| e.path() == *cwd || !matcher.is_ignored(e.path()))
         {
             let Ok(entry) = entry else { continue };
             let path = entry.path().to_path_buf();
             let file_type = entry.file_type();
 
             if file_type.is_dir() {
-                self.tracked_dirs.entry(path.clone()).or_default();
-                if path != cwd {
+                if &path != cwd {
                     if let (Some(parent), Some(name)) = (path.parent(), path.file_name()) {
-                        self.tracked_dirs
+                        tracked_dirs
                             .entry(parent.to_path_buf())
                             .or_default()
                             .insert(name.to_os_string());
                     }
                 }
-            } else if (file_type.is_file() || file_type.is_symlink())
-                && self.matcher.is_emittable(&path)
+                tracked_dirs.entry(path).or_default();
+            } else if (file_type.is_file() || file_type.is_symlink()) && matcher.is_emittable(&path)
             {
-                self.tracked_files.insert(path.clone());
                 if let (Some(parent), Some(name)) = (path.parent(), path.file_name()) {
-                    self.tracked_dirs
+                    tracked_dirs
                         .entry(parent.to_path_buf())
                         .or_default()
                         .insert(name.to_os_string());
                 }
+                tracked_files.insert(path);
             }
         }
     }
@@ -460,30 +469,33 @@ impl WatcherState {
         self.last_remove.insert(path.clone(), now);
 
         if was_tracked_dir {
-            // Collect children *before* modifying tracked_dirs so the borrow ends.
-            let children: Vec<OsString> = self
-                .tracked_dirs
-                .get(&path)
-                .map(|s| s.iter().cloned().collect())
-                .unwrap_or_default();
-            self.tracked_dirs.remove(&path);
-            released.push(path.clone());
-            for child in children {
-                self.handle_deletion(path.join(&child), released);
+            let children = self.tracked_dirs.remove(&path).unwrap_or_default();
+            for child in &children {
+                self.handle_deletion(path.join(child), released);
             }
         }
 
         if was_tracked_file {
             self.tracked_files.remove(&path);
-            if self.events.contains(&EventType::Delete) {
-                // Defer: wait for a possible same-path Add within the atomic window.
-                self.pending_unlinks.insert(path.clone(), now);
-            }
         }
 
         // Remove from parent's child set.
         if let Some(parent_set) = self.tracked_dirs.get_mut(&parent) {
             parent_set.remove(&name);
+        }
+
+        let defer_unlink = was_tracked_file && self.events.contains(&EventType::Delete);
+        match (was_tracked_dir, defer_unlink) {
+            (true, true) => {
+                released.push(path.clone());
+                // Defer: wait for a possible same-path Add within the atomic window.
+                self.pending_unlinks.insert(path, now);
+            }
+            (true, false) => released.push(path),
+            (false, true) => {
+                self.pending_unlinks.insert(path, now);
+            }
+            (false, false) => {}
         }
     }
 
@@ -494,11 +506,12 @@ impl WatcherState {
         acquired: &mut Vec<PathBuf>,
         released: &mut Vec<PathBuf>,
     ) {
-        // Track new directories so the hub can install a watch on them.
-        if !self.tracked_dirs.contains_key(&path) {
-            acquired.push(path.clone());
-        }
-        self.tracked_dirs.entry(path.clone()).or_default();
+        // Take the previous child set out of self so we can mutate `self`
+        // freely below without re-borrowing it for the diff.
+        let prev_opt = self.tracked_dirs.remove(&path);
+        let already_tracked = prev_opt.is_some();
+        let mut prev = prev_opt.unwrap_or_default();
+
         if path != self.cwd {
             if let (Some(parent), Some(name)) = (path.parent(), path.file_name()) {
                 self.tracked_dirs
@@ -510,7 +523,11 @@ impl WatcherState {
 
         // Snapshot what's currently on disk (filtered).
         let current: HashSet<OsString> = match fs::read_dir(&path) {
-            Err(_) => return,
+            Err(_) => {
+                // Restore the previous tracking so we don't lose state on a transient stat failure.
+                self.tracked_dirs.insert(path, prev);
+                return;
+            }
             Ok(rd) => rd
                 .filter_map(Result::ok)
                 .filter_map(|entry| {
@@ -529,13 +546,19 @@ impl WatcherState {
                 .collect(),
         };
 
-        // Snapshot the previously-tracked children.
-        let tracked: HashSet<OsString> = self.tracked_dirs.get(&path).cloned().unwrap_or_default();
-
-        // New entries (on disk, not yet tracked) → dispatch each.
-        let new_entries: Vec<OsString> = current.difference(&tracked).cloned().collect();
-        // Gone entries (tracked, not on disk) → deletion path.
-        let gone_entries: Vec<OsString> = tracked.difference(&current).cloned().collect();
+        // Partition by moving OsStrings instead of cloning:
+        //   - in current and prev   → intersection (still tracked)
+        //   - in current, not prev  → new_entries  (dispatch as new)
+        //   - in prev, not current  → gone        (left in `prev`, then deleted)
+        let mut new_entries: Vec<OsString> = Vec::new();
+        let mut intersection: HashSet<OsString> = HashSet::with_capacity(prev.len());
+        for name in current {
+            if prev.remove(&name) {
+                intersection.insert(name);
+            } else {
+                new_entries.push(name);
+            }
+        }
 
         for name in new_entries {
             let child = path.join(&name);
@@ -543,9 +566,20 @@ impl WatcherState {
                 self.dispatch(&child, kind, queue, acquired, released);
             }
         }
-        for name in gone_entries {
+        for name in prev {
             self.handle_deletion(path.join(&name), released);
         }
+
+        // Track new directories so the hub can install a watch on them.
+        if !already_tracked {
+            acquired.push(path.clone());
+        }
+        // Dispatch repopulated tracked_dirs[path] with the new entries; merge the
+        // surviving intersection back in so the entry mirrors on-disk state.
+        self.tracked_dirs
+            .entry(path)
+            .or_default()
+            .extend(intersection);
     }
 
     fn handle_file(&mut self, path: PathBuf, queue: &mut Vec<Report>) {
@@ -565,20 +599,21 @@ impl WatcherState {
         let was_tracked = self.tracked_files.contains(&path);
         let now = Instant::now();
 
-        if self.pending_unlinks.contains_key(&path) {
+        if self.pending_unlinks.remove(&path).is_some() {
             // Atomic write: an unlink was pending for this path and an add arrived.
             // Emit change instead of (delete + create).
-            self.pending_unlinks.remove(&path);
-            self.tracked_files.insert(path.clone());
             self.tracked_dirs.entry(parent).or_default().insert(name);
 
             if self.events.contains(&EventType::Change) && self.allow_change(&path, now) {
+                self.tracked_files.insert(path.clone());
                 queue.push(Report {
                     uid: self.uid,
                     event: EventType::Change,
                     path,
                     timestamp: now,
                 });
+            } else {
+                self.tracked_files.insert(path);
             }
         } else if was_tracked {
             // Known file — emit change with 50 ms throttle.
@@ -592,16 +627,18 @@ impl WatcherState {
             }
         } else {
             // New file — emit create.
-            self.tracked_files.insert(path.clone());
             self.tracked_dirs.entry(parent).or_default().insert(name);
 
             if self.events.contains(&EventType::Create) {
+                self.tracked_files.insert(path.clone());
                 queue.push(Report {
                     uid: self.uid,
                     event: EventType::Create,
                     path,
                     timestamp: now,
                 });
+            } else {
+                self.tracked_files.insert(path);
             }
         }
     }
@@ -630,25 +667,20 @@ impl WatcherState {
             .retain(|_, &mut t| now.saturating_duration_since(t) < remove_window);
 
         let mut earliest: Option<Instant> = None;
-        let mut to_flush: Vec<(PathBuf, Instant)> = Vec::new();
-
-        for (path, &orig) in &self.pending_unlinks {
+        let pending = mem::take(&mut self.pending_unlinks);
+        for (path, orig) in pending {
             let deadline = orig + window;
             if now >= deadline {
-                to_flush.push((path.clone(), orig));
+                queue.push(Report {
+                    uid: self.uid,
+                    event: EventType::Delete,
+                    path,
+                    timestamp: orig,
+                });
             } else {
                 earliest = Some(earliest.map_or(deadline, |e| e.min(deadline)));
+                self.pending_unlinks.insert(path, orig);
             }
-        }
-
-        for (path, orig) in to_flush {
-            self.pending_unlinks.remove(&path);
-            queue.push(Report {
-                uid: self.uid,
-                event: EventType::Delete,
-                path,
-                timestamp: orig,
-            });
         }
 
         earliest
@@ -736,8 +768,7 @@ fn register_watcher(reg: Register, hub: HubHandle, states: States) {
 
 fn dispatch_worker(
     rx: mpsc::Receiver<notify::Event>,
-    #[allow(unused_variables)]
-    hub: HubHandle,
+    #[allow(unused_variables)] hub: HubHandle,
     queue: Queue,
     states: States,
 ) {
@@ -745,8 +776,8 @@ fn dispatch_worker(
         // Stat each path once; reuse across all watchers.
         let path_kinds: Vec<(PathBuf, PathKind)> = event
             .paths
-            .iter()
-            .filter_map(|p| classify(p).map(|k| (p.clone(), k)))
+            .into_iter()
+            .filter_map(|p| classify(&p).map(|k| (p, k)))
             .collect();
 
         let state_arcs: Vec<Arc<Mutex<WatcherState>>> = {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use notify::Watcher as _;
 use serde::Deserialize;
 use walkdir::WalkDir;
 
-#[cfg(any(target_os = "linux", windows))]
+#[cfg(any(target_os = "linux", target_os = "macos", windows))]
 fn parent_died() -> ! {
     eprintln!("parent process died");
     exit(1);
@@ -43,6 +43,60 @@ fn parent_process_watchdog() -> ! {
             Ok(_) => parent_died(),
             Err(Errno::INTR) => {}
             Err(e) => panic!("poll failed: {e:?}"),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn parent_process_watchdog() -> ! {
+    use libc::{kevent, kqueue, EVFILT_PROC, EV_ADD, EV_ONESHOT, NOTE_EXIT};
+
+    let ppid = unsafe { libc::getppid() };
+    if ppid <= 1 {
+        parent_died();
+    }
+
+    let kq = unsafe { kqueue() };
+    if kq < 0 {
+        parent_died();
+    }
+
+    #[allow(clippy::cast_sign_loss)]
+    let change = kevent {
+        ident: ppid as usize,
+        filter: EVFILT_PROC,
+        flags: EV_ADD | EV_ONESHOT,
+        fflags: NOTE_EXIT,
+        data: 0,
+        udata: std::ptr::null_mut(),
+    };
+
+    // Registration returns ESRCH if the parent already died.
+    let ret = unsafe {
+        kevent(
+            kq,
+            &raw const change,
+            1,
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null(),
+        )
+    };
+    if ret < 0 {
+        parent_died();
+    }
+
+    let mut event = unsafe { std::mem::zeroed::<kevent>() };
+    loop {
+        let n = unsafe { kevent(kq, std::ptr::null(), 0, &raw mut event, 1, std::ptr::null()) };
+        if n > 0 {
+            parent_died();
+        }
+        if n < 0 {
+            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+            if errno != libc::EINTR {
+                parent_died();
+            }
         }
     }
 }
@@ -798,6 +852,8 @@ fn main() {
         enter_efficiency_mode();
         drop(thread::spawn(parent_process_watchdog));
     }
+    #[cfg(target_os = "macos")]
+    drop(thread::spawn(parent_process_watchdog));
 
     let queue: Queue = Box::leak(Box::new(Mutex::new(Vec::new())));
     let states: States = Box::leak(Box::new(Mutex::new(HashMap::new())));


### PR DESCRIPTION
## Summary

Follow-up to #1. Addresses the macOS shutdown hang reported by @rchl:

> the rust-process is not shutting down for me often when closing ST (on mac). In that case it will also sit using 20% of CPU typically or sometimes even jump to 100%.

Root cause: `parent_process_watchdog` was only compiled for Linux/Windows, so on macOS the child relied solely on stdin EOF. When ST exits without cleanly closing pipes, FSEvents keeps delivering events while stdin remains open, burning CPU until EOF eventually arrives.

## Changes

- **fix: implement parent process watchdog in macOS** — kqueue `EVFILT_PROC | NOTE_EXIT` watchdog thread on macOS, mirroring the Linux (pidfd + poll) and Windows (`WaitForSingleObject`) designs. Edge-triggered, no polling.
- **chore: add parent died test in CI** — `scripts/watchdog_check.sh` (+ `watchdog_check.ps1` for Windows) orphans the rust-watcher process via a wrapper whose stdin is held open by an unrelated keeper, then verifies the watchdog kills it within 5s. Wired into the CI matrix on Linux, macOS, and Windows.
- **feat: enter_efficiency_mode implementation for macOS** — `setpriority(PRIO_DARWIN_PROCESS, 0, PRIO_DARWIN_BG)` (the macOS analog of `SCHED_BATCH` / EcoQoS).
- **refactor: depend on libc on Linux as well** — drop the `rustix` git-fork dependency; reimplement the Linux watchdog and `sched_setscheduler` call directly on `libc`. Builds no longer need network access for an out-of-tree crate.

## Test plan

- [x] CI green on Linux, macOS, Windows — watchdog fires in 0s on all three.
- [ ] @rchl could you give this a try on macOS? I don't have a Mac to verify the original shutdown-hang scenario end-to-end. Repro: launch ST with the plugin enabled, force-kill ST, confirm `rust-watcher` exits within ~1s and CPU does not spike.